### PR TITLE
updated getCatEIA for vectorization

### DIFF
--- a/R/source.R
+++ b/R/source.R
@@ -121,20 +121,22 @@ getCatEIA <- function(cat=999999999, key){
          
          url <- paste("http://api.eia.gov/category?api_key=", key, "&category_id=", cat, "&out=xml", sep="" )
   )
-  doc <- FALSE
+  doc <- readLines(url, warn = FALSE)
   for( i in 1:3 ) {
-      doc <- tryCatch( xmlParse(file = url, isURL = TRUE), warning = function(w) FALSE, 
-                       error = function(w) FALSE)
+      doc <- tryCatch( xmlParse(doc, warning = function(w) FALSE, error = function(w) FALSE)) 
+                              #options = c(NOERROR, NOWARNING))   #
       if (class(doc) != "logical")
           break
       else
           if(i == 3)
-              stop(paste0("Attempted to parse category #", cat, 
+              stop(paste0("Attempted to retrieve data for category #", cat, 
                        " and failed ", i, " times. \n This is likely due to a communication error ", 
                        "with the EIA website."))
   }
   
-  Parent_Category <- tryCatch(xmlToDataFrame(nodes = XML::getNodeSet(doc, "//category/parent_category_id")), warning=function(w) FALSE, error=function(w) FALSE)
+  Parent_Category <- tryCatch(xmlToDataFrame(
+      nodes = XML::getNodeSet(doc, "//category/parent_category_id")), 
+      warning=function(w) FALSE, error=function(w) FALSE)
   
   Sub_Categories <- xmlToDataFrame(nodes = XML::getNodeSet(doc, "//childcategories/row"))
   

--- a/R/source.R
+++ b/R/source.R
@@ -148,4 +148,3 @@ getCatEIA <- function(cat=999999999, key){
 
   return(Categories)
 }
-}

--- a/R/source.R
+++ b/R/source.R
@@ -113,20 +113,21 @@ getEIA <- function(ID, key){
 }
 
 getCatEIA <- function(cat=999999999, key){
-
+    
   key <- unlist(strsplit(key, ";"))
 
   ifelse(cat==999999999,
          url <- paste("http://api.eia.gov/category?api_key=", key, "&out=xml", sep="" ),
          
-         url <- paste("http://api.eia.gov/category?api_key=", key, "&category_id=", cat, "&out=xml", sep="" )
+         url <- paste("http://api.eia.gov/category?api_key=", key, 
+                      "&category_id=", cat, "&out=xml", sep="" )
   )
-  doc <- readLines(url, warn = FALSE)
   for( i in 1:3 ) {
-      doc <- tryCatch( xmlParse(doc, warning = function(w) FALSE, error = function(w) FALSE)) 
-                              #options = c(NOERROR, NOWARNING))   #
-      if (class(doc) != "logical")
+      doc <- tryCatch(readLines(url, warn = FALSE), error = function(w) FALSE)
+      if (class(doc) != "logical"){
+          doc <- xmlParse(doc)
           break
+      }
       else
           if(i == 3)
               stop(paste0("Attempted to retrieve data for category #", cat, 
@@ -146,4 +147,5 @@ getCatEIA <- function(cat=999999999, key){
   names(Categories) <- c("Parent_Category", "Sub_Categories", "Series_IDs")
 
   return(Categories)
+}
 }

--- a/R/source.R
+++ b/R/source.R
@@ -112,22 +112,32 @@ getEIA <- function(ID, key){
   return(temp)
 }
 
-getCatEIA <- function(key, cat=999999999){
+getCatEIA <- function(cat=999999999, key){
 
   key <- unlist(strsplit(key, ";"))
 
   ifelse(cat==999999999,
          url <- paste("http://api.eia.gov/category?api_key=", key, "&out=xml", sep="" ),
-
+         
          url <- paste("http://api.eia.gov/category?api_key=", key, "&category_id=", cat, "&out=xml", sep="" )
-         )
-
-  doc <- xmlParse(file=url, isURL=TRUE)
-
+  )
+  doc <- FALSE
+  for( i in 1:3 ) {
+      doc <- tryCatch( xmlParse(file = url, isURL = TRUE), warning = function(w) FALSE, 
+                       error = function(w) FALSE)
+      if (class(doc) != "logical")
+          break
+      else
+          if(i == 3)
+              stop(paste0("Attempted to parse category #", cat, 
+                       " and failed ", i, " times. \n This is likely due to a communication error ", 
+                       "with the EIA website."))
+  }
+  
   Parent_Category <- tryCatch(xmlToDataFrame(nodes = XML::getNodeSet(doc, "//category/parent_category_id")), warning=function(w) FALSE, error=function(w) FALSE)
-
+  
   Sub_Categories <- xmlToDataFrame(nodes = XML::getNodeSet(doc, "//childcategories/row"))
-
+  
   Series_IDs <- xmlToDataFrame(nodes = XML::getNodeSet(doc, "///childseries/row"))
 
   Categories <- list(Parent_Category, Sub_Categories, Series_IDs)


### PR DESCRIPTION
getCatEIA was updated to support vectorization through the *apply family of functions and readLines function is employed as a lower level alternative to xmlParse performing the download of the file from api.eia.gov.  I found it hard to debug xmlParse errors when the EIA site returns no data for category IDs which actually exist when run manually.  I suppose other functions could employ a similar approach though I haven't checked them in detail at this point.
