### PR TITLE
Speed improvements when converting to a data.frame

### DIFF
--- a/R/source.R
+++ b/R/source.R
@@ -25,8 +25,11 @@ getEIA <- function(ID, key){
 
   doc <- xmlParse(file=url, isURL=TRUE)
 
-  df <- xmlToDataFrame(nodes = XML::getNodeSet(doc, "//data/row"))
-
+  df <- data.frame(
+    date = sapply(doc["//data/row/date"], xmlValue),
+    value = sapply(doc["//data/row/value"], xmlValue)
+  )
+  
 ### Sort from oldest to newest ----
   df <- df[ with(df, order(date)), ]
 
@@ -50,8 +53,11 @@ getEIA <- function(ID, key){
 
   doc <- xmlParse(file=url, isURL=TRUE)
 
-  df <- xmlToDataFrame(nodes = XML::getNodeSet(doc, "//data/row"))
-
+  df <- data.frame(
+    date = sapply(doc["//data/row/date"], xmlValue),
+    value = sapply(doc["//data/row/value"], xmlValue)
+  )
+  
 ### Sort from oldest to newest ----
   df <- df[ with(df, order(date)), ]
 
@@ -74,8 +80,11 @@ getEIA <- function(ID, key){
 
   doc <- xmlParse(file=url, isURL=TRUE)
 
-  df <- xmlToDataFrame(nodes = XML::getNodeSet(doc, "//data/row"))
-
+  df <- data.frame(
+    date = sapply(doc["//data/row/date"], xmlValue),
+    value = sapply(doc["//data/row/value"], xmlValue)
+  )
+  
 ### Sort from oldest to newest ----
   df <- df[ with(df, order(date)), ]
 
@@ -98,7 +107,11 @@ getEIA <- function(ID, key){
 
   doc <- xmlParse(file=url, isURL=TRUE)
 
-  df <- xmlToDataFrame(nodes = XML::getNodeSet(doc, "//data/row"))
+    df <- data.frame(
+      date = sapply(doc["//data/row/date"], xmlValue),
+      value = sapply(doc["//data/row/value"], xmlValue)
+    )
+
 
 ### Sort from oldest to newest ----
   df <- df[ with(df, order(date)), ]
@@ -119,8 +132,13 @@ getEIA <- function(ID, key){
   key <- unlist(strsplit(key, ";"))
   url <- paste("http://api.eia.gov/series?series_id=", ID, "&api_key=", key, "&out=xml", sep="" )
   doc <- xmlParse(file=url, isURL=TRUE)
-  df <- xmlToDataFrame(nodes = XML::getNodeSet(doc, "//data/row"))
+  
+  df <- data.frame(
+    date = sapply(doc["//data/row/date"], xmlValue),
+    value = sapply(doc["//data/row/value"], xmlValue)
+  )
 
+  
 ### Sort from oldest to newest ----
   df <- df[ with(df, order(date)), ]
  


### PR DESCRIPTION
I found that:
```
df <- data.frame(
    date = sapply(doc["//data/row/date"], xmlValue),
    value = sapply(doc["//data/row/value"], xmlValue)
)
```
is a much faster way to turn the data into a data.frame than the current method. On my machines. performance of the `getEIA()` function roughly doubles doing it this way for large data sets such as hourly and daily data. The change on the quarterly or annual data is negligible since so little processing time is spent on converting it to a data.frame in the first place.